### PR TITLE
Use unpacked scripts to do the complicated steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  run-tests:
+  run-ci:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,7 @@ jobs:
         uses: cachix/cachix-action@v16
         with:
           name: pkg-pl
-      - name: Run tests
+      - name: Run CI
         run: |
           nix develop --command \
-            just test
+            just ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.direnv
+*.gen

--- a/example/main.pl
+++ b/example/main.pl
@@ -4,10 +4,10 @@
 % Loads a package. The argument should be an atom equal to the name of the
 % dependency package specified in the `name/1` field of its manifest.
 :- use_module(pkg(testing)).
-:- use_module(pkg(foo_branch)).
-:- use_module(pkg(foo_tag)).
-:- use_module(pkg(foo)).
-:- use_module(pkg(local_package)).
+:- use_module(pkg(test_branch)).
+:- use_module(pkg(test_tag)).
+:- use_module(pkg(test_hash)).
+:- use_module(pkg(test_local)).
 
 % You can then use the predicates exported by the main file of the dependency
 % in the rest of the program.

--- a/example/scryer-manifest.pl
+++ b/example/scryer-manifest.pl
@@ -4,13 +4,13 @@ main_file("main.pl").
 % Optional
 dependencies([
     % A git url to clone
-    git("https://github.com/bakaq/testing.pl.git"),
+    dependency("testing", git("https://github.com/bakaq/testing.pl.git")),
     % A git url to clone at a specific branch
-    git("https://github.com/constraintAutomaton/test-prolog-package-manager.git", branch("branch")),
+    dependency("test_branch", git("https://github.com/constraintAutomaton/test-prolog-package-manager.git", branch("branch"))),
     % A git url to clone at a tag
-    git("https://github.com/constraintAutomaton/test-prolog-package-manager.git", tag("tag")),
+    dependency("test_tag", git("https://github.com/constraintAutomaton/test-prolog-package-manager.git", tag("tag"))),
     % A git url to clone at a specific commit hash
-    git("https://github.com/constraintAutomaton/test-prolog-package-manager.git", hash("d19fefc1d7907f6675e181601bb9b8b94561b441")),
+    dependency("test_hash", git("https://github.com/constraintAutomaton/test-prolog-package-manager.git", hash("d19fefc1d7907f6675e181601bb9b8b94561b441"))),
     % A path to a local package
-    path("./local_package")
+    dependency("test_local", path("./local_package"))
 ]).

--- a/justfile
+++ b/justfile
@@ -1,7 +1,40 @@
 default:
     @just --list
 
-test: test-example
+build: codegen
+    mv pkg.pl.gen pkg.pl
+
+codegen:
+    #!/bin/sh
+    set -eu
+
+    sed -e "/% === Generated code start ===/q" pkg.pl > pkg.pl.gen
+
+    for file in scripts/*.sh; do
+        script_string=$(scryer-prolog -f -g "
+            use_module(library(pio)),
+            use_module(library(dcgs)),
+            phrase_from_file(seq(Script),\"${file}\"),
+            write_term(Script, [quoted(true),double_quotes(true)]),
+            halt.
+        ")
+        script_name=$(basename -s .sh ${file})
+        printf '%s\n' "script_string(\"${script_name}\", ${script_string})." >> pkg.pl.gen
+    done
+    sed -n -e "/% === Generated code end ===/,$ {p}" pkg.pl >> pkg.pl.gen
+
+codegen-check: codegen
+    diff pkg.pl pkg.pl.gen
+
+# All the checks made in CI
+ci: codegen-check test
+
+test: build test-example
 
 test-example:
     just example/test
+
+clean-codegen:
+    rm -f pkg.pl.gen
+
+clean: clean-codegen

--- a/scripts/ensure_dependency.sh
+++ b/scripts/ensure_dependency.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+echo "Ensuring is installed: ${DEPENDENCY_TERM}"
+
+rm --recursive --force scryer_libs/tmp-package
+
+relocate_tmp() {
+    rm --recursive --force "scryer_libs/packages/${DEPENDENCY_NAME}"
+    mv scryer_libs/tmp-package "scryer_libs/packages/${DEPENDENCY_NAME}"
+}
+
+case "${DEPENDENCY_KIND}" in
+    git_default)
+        git clone \
+            --quiet \
+            --depth 1 \
+            --single-branch \
+            "${GIT_URL}" \
+            scryer_libs/tmp-package
+        relocate_tmp
+        ;;
+    git_branch)
+        git clone \
+            --quiet \
+            --depth 1 \
+            --single-branch \
+            --branch "${GIT_BRANCH}" \
+            "${GIT_URL}" \
+            scryer_libs/tmp-package
+        relocate_tmp
+        ;;
+    git_tag)
+        git clone \
+            --quiet \
+            --depth 1 \
+            --single-branch \
+            --branch "${GIT_TAG}" \
+            "${GIT_URL}" \
+            scryer_libs/tmp-package
+        relocate_tmp
+        ;;
+    git_hash)
+        git clone \
+            --quiet \
+            --depth 1 \
+            --single-branch \
+            "${GIT_URL}" \
+            scryer_libs/tmp-package
+        git -C scryer_libs/tmp-package fetch \
+            --quiet \
+            --depth 1 \
+            origin "${GIT_HASH}"
+        git -C scryer_libs/tmp-package switch \
+            --quiet \
+            --detach \
+            "${GIT_HASH}"
+        relocate_tmp
+        ;;
+    path)
+        ln -rsf "${DEPENDENCY_PATH}" "scryer_libs/packages/${DEPENDENCY_NAME}"
+        ;;
+    *)
+        echo "Unknown dependency kind"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Aka: Hell yeah, no more injection attack!

This introduces a "code generation" step that embeds shell scripts into the `pkg.pl` file (CI checks that's always up-to-date). On use when creating the `scryer_libs` directory it unpacks the scripts into `scryer_libs/scripts` so that it can use them. Packages are now installed in `scryer_libs/packages` instead to avoid collisions and allow us to put more stuff into `scryer_libs` in the future (caches?).

The big hack here is that I noticed we can pass "arguments" to shell scripts with environment variables with no need for escaping. I introduce the predicate `run_script_with_args/2` to make this pattern easier. If there is need to read some kind of output of a script I think we still need to make a file somewhere, but that is not a big deal, at least not compared to this abomination I'm describing. We should probably standardize in a consistent way to do this though, probably a temporary file inside `scryer_libs`, maybe multiple depending on the script in question.

We are already pretty dependent on `sh` in the current `main`, so this isn't much of a portability loss. In fact, this can probably be extended very easily to have Powershell versions of the scripts to support Windows when time comes. Something like `library(process)` would probably be better, but this scheme here can take us very far while only demanding host implementations to have `shell/1` and environment management predicates.

@constraintAutomaton, this will probably make your life easier in #16 too. Much less pain to just write a shell script when we need it.