### PR TITLE
Use --ignore-env in CI for better reproducibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
           name: pkg-pl
       - name: Run CI
         run: |
-          nix develop --command \
+          nix develop --ignore-env --command \
             just ci


### PR DESCRIPTION
This makes sure that the CI can't use anything from the underlying runner. In particular this doesn't provide the `PATH`, so we can't use programs installed in the runner; everything we use must be defined in the flake. I can't see any reason to _not_ do this so here we go.