### PR TITLE
Add basic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  main-release:
+    if: github.ref_type == 'branch' && github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          files: bakage.pl


### PR DESCRIPTION
Preliminary, but we need to have this eventually instead of just checking in the built file.

I'm not sure if this will work, but the idea is to always build and release the main branch so that we have some kind of nightly. It's essential now that we are before an MVP, and will also be useful after that.

When we have a more complicated build process we would do that instead of just picking the file from the repo.