### PR TITLE
Remove the hesitation about the manifest schema in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ get in touch and create issues, pull requests and
 
 ## How to use
 
-A package is a directory with a `scryer-manifest.pl`, the current schema is something like:
+A package is a directory with a `scryer-manifest.pl` following this schema:
 
 ```prolog
 name("name_of_the_package").


### PR DESCRIPTION
I think we exactly know what is the schema we expected and also the user _should_ expect the readme to be up to date.